### PR TITLE
Modifications for openmm

### DIFF
--- a/macha/data/templates/default/openmm_run.py
+++ b/macha/data/templates/default/openmm_run.py
@@ -17,7 +17,6 @@ import os
 from omm_readinputs import *
 from omm_readparams import *
 from omm_vfswitch import *
-from data.templates.default.omm_barostat import *
 from omm_restraints import *
 from omm_rewrap import *
 

--- a/macha/functions.py
+++ b/macha/functions.py
@@ -233,9 +233,9 @@ class Preparation:
         pdb_file_orig = f"{self.original_dir}/{self.ligand_id}.pdb"
         pdb_file = self._remove_lp(pdb_file_orig)
         df = pdb_file.to_dataframe()
-        segids = set(i.residue.segid for i in pdb_file)
+        segids = set(i.residue.chain for i in pdb_file)
         if (
-            len(segids) < 1
+            len(segids) > 3
         ):  # for pdb file created with MAESTRO containing the chaing segment
             print(f"Processing a Maestro based pdb file")
             aa = [
@@ -263,6 +263,9 @@ class Preparation:
                 "HID",
                 "HIE",
                 "HIP",
+                "TPO",
+                "HSE",
+                "HSD",
             ]  # we need to find the residue of the ligand which should be the only one being not an aa
             for (
                 chain
@@ -386,10 +389,6 @@ class CharmmManipulation:
         file = open(f"{self.ligand_id}/{self.env}/toppar.str", "a")
         file.write(f"stream {self.resname.lower()}/{self.resname.lower()}.str")
         file.close()
-        # manipulate toppar.str file for use with openmm
-        file = open(f"{self.ligand_id}/{self.env}/openmm/toppar.str", "a")
-        file.write(f"stream ../{self.resname.lower()}/{self.resname.lower()}.str")
-        file.close()
 
     def copyFiles(self):
 
@@ -404,18 +403,8 @@ class CharmmManipulation:
             f"{self.default_path}/toppar.str", f"{self.ligand_id}/{self.env}/openmm/toppar.str"
         )
         shutil.copy(
-            f"{self.default_path}/omm_step4_equilibration.inp", f"{self.ligand_id}/{self.env}/openmm/step4_equilibration.inp"
-        )
-        shutil.copy(
-            f"{self.default_path}/omm_step5_production.inp", f"{self.ligand_id}/{self.env}/openmm/step5_production.inp"
-        )
-        shutil.copy(
             f"{self.default_path}/checkfft.py", f"{self.ligand_id}/{self.env}/checkfft.py"
         )
-
-        # copy files for OpenMM
-        for file in glob.glob(f"{self.default_path}/[!checkfft.py]*py"):
-            shutil.copy(file, f"{self.ligand_id}/{self.env}/openmm/")
 
         try:
             shutil.copytree(
@@ -522,4 +511,43 @@ class CharmmManipulation:
                         assert atom.mass > 1.5
         except:
             print("Masses were left unchanged! HMR not possible, check your output! ")
+
+    def createOpenMMSystem(self):
+
+        # copy files for OpenMM
+        for file in glob.glob(f"{self.default_path}/[!checkfft.py]*py"):
+            shutil.copy(file, f"{self.ligand_id}/{self.env}/openmm/")
+
+        shutil.copy(
+            f"{self.default_path}/omm_step4_equilibration.inp", f"{self.ligand_id}/{self.env}/openmm/step4_equilibration.inp"
+        )
+        shutil.copy(
+            f"{self.default_path}/omm_step5_production.inp", f"{self.ligand_id}/{self.env}/openmm/step5_production.inp"
+        )
+
+        # manipulate toppar.str file for use with openmm
+        file = open(f"{self.ligand_id}/{self.env}/openmm/toppar.str", "a")
+        file.write(f"../{self.resname.lower()}/{self.resname.lower()}.str")
+        file.close()
+
+        # Create sysinfo.dat file, which contains information about the box
+        file = open(f"{self.ligand_id}/{self.env}/step3_pbcsetup.str")
+        for line in file:
+            if line.startswith(f" SET A "):
+                a = line.split(' ')[-1].strip()
+            elif line.startswith(f" SET B "):
+                b = line.split(' ')[-1].strip()
+            elif line.startswith(f" SET C "):
+                c = line.split(' ')[-1].strip()
+            elif line.startswith(f" SET ALPHA "):
+                alpha = line.split(' ')[-1].strip()
+            elif line.startswith(f" SET BETA "):
+                beta = line.split(' ')[-1].strip()
+            elif line.startswith(f" SET GAMMA "):
+                gamma = line.split(' ')[-1].strip()  
+
+        with open(f"{self.ligand_id}/{self.env}/openmm/sysinfo.dat","w") as f:
+            f.write('{"dimensions"}:['+f'{a}, {b}, {c}, {alpha}, {beta}, {gamma}'+']}')  
+
+
 

--- a/macha/functions.py
+++ b/macha/functions.py
@@ -547,7 +547,7 @@ class CharmmManipulation:
                 gamma = line.split(' ')[-1].strip()  
 
         with open(f"{self.ligand_id}/{self.env}/openmm/sysinfo.dat","w") as f:
-            f.write('{"dimensions"}:['+f'{a}, {b}, {c}, {alpha}, {beta}, {gamma}'+']}')  
+            f.write('{"dimensions":['+f'{a}, {b}, {c}, {alpha}, {beta}, {gamma}'+']}')  
 
 
 

--- a/macha/functions.py
+++ b/macha/functions.py
@@ -481,41 +481,45 @@ class CharmmManipulation:
 
     def applyHMR(self):
 
-        if not os.path.isfile(f"{self.ligand_id}/{self.env}/openmm/step3_input_orig.psf"):
+        try:
 
-            parms = ()
-            for file in glob.glob(f"{self.ligand_id}/{self.env}/toppar/*[!tip216.crd]*"):
-                parms += ( file, )
+            if not os.path.isfile(f"{self.ligand_id}/{self.env}/openmm/step3_input_orig.psf"):
 
-            parms += (f"{self.ligand_id}/{self.env}/{self.resname.lower()}/{self.resname.lower()}.str",)
-            params = pm.charmm.CharmmParameterSet(*parms)
+                parms = ()
+                for file in glob.glob(f"{self.ligand_id}/{self.env}/toppar/*[!tip216.crd]*"):
+                    parms += ( file, )
 
-            shutil.copy(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf",f"{self.ligand_id}/{self.env}/openmm/step3_input_orig.psf")
-            psf = pm.charmm.CharmmPsfFile(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf")
-            psf.load_parameters(params)
-            pm.tools.actions.HMassRepartition(psf).execute()
-            psf.save(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf", overwrite = True)
+                parms += (f"{self.ligand_id}/{self.env}/{self.resname.lower()}/{self.resname.lower()}.str",)
+                params = pm.charmm.CharmmParameterSet(*parms)
 
-            # assure that mass is greater than one
-            for atom in psf:
-                if atom.name.startswith("H") and atom.residue.name != 'TIP3':
-                    assert atom.mass > 1.5
-        else:
-            
-            parms = ()
-            for file in glob.glob(f"{self.ligand_id}/{self.env}/toppar/*[!tip216.crd]*"):
-                parms += ( file, )
+                shutil.copy(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf",f"{self.ligand_id}/{self.env}/openmm/step3_input_orig.psf")
+                psf = pm.charmm.CharmmPsfFile(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf")
+                psf.load_parameters(params)
+                pm.tools.actions.HMassRepartition(psf).execute()
+                psf.save(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf", overwrite = True)
 
-            parms += (f"{self.ligand_id}/{self.env}/{self.resname.lower()}/{self.resname.lower()}.str",)
-            params = pm.charmm.CharmmParameterSet(*parms)
+                # assure that mass is greater than one
+                for atom in psf:
+                    if atom.name.startswith("H") and atom.residue.name != 'TIP3':
+                        assert atom.mass > 1.5
+            else:
+                
+                parms = ()
+                for file in glob.glob(f"{self.ligand_id}/{self.env}/toppar/*[!tip216.crd]*"):
+                    parms += ( file, )
 
-            psf = pm.charmm.CharmmPsfFile(f"{self.ligand_id}/{self.env}/openmm/step3_input_orig.psf")
-            psf.load_parameters(params)
-            pm.tools.actions.HMassRepartition(psf).execute()
-            psf.save(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf", overwrite = True)
+                parms += (f"{self.ligand_id}/{self.env}/{self.resname.lower()}/{self.resname.lower()}.str",)
+                params = pm.charmm.CharmmParameterSet(*parms)
 
-            # assure that mass is greater than one
-            for atom in psf:
-                if atom.name.startswith("H") and atom.residue.name != 'TIP3':
-                    assert atom.mass > 1.5
+                psf = pm.charmm.CharmmPsfFile(f"{self.ligand_id}/{self.env}/openmm/step3_input_orig.psf")
+                psf.load_parameters(params)
+                pm.tools.actions.HMassRepartition(psf).execute()
+                psf.save(f"{self.ligand_id}/{self.env}/openmm/step3_input.psf", overwrite = True)
+
+                # assure that mass is greater than one
+                for atom in psf:
+                    if atom.name.startswith("H") and atom.residue.name != 'TIP3':
+                        assert atom.mass > 1.5
+        except:
+            print("Masses were left unchanged! HMR not possible, check your output! ")
 

--- a/macha/main.py
+++ b/macha/main.py
@@ -13,7 +13,7 @@ from functions import check_ligands, Preparation, CharmmManipulation
 ################################################################################
 
 parent_dir = "."
-original_dir = "original"
+original_dir = "data/original"
 ligands_dir = "../ligands"
 input_ext = "pdb"  # for testing - should be pdb
 cgenff_path = "/site/raid2/johannes/programs/silcsbio/silcsbio.2022.1/cgenff/cgenff"
@@ -60,5 +60,6 @@ for ligand_id in ligand_ids:
         # Modify step1_pdbreader.inp to read in correct amount of chains/residues
         charmmManipulation.modifyStep1(segids)
         # Run Charmm giving the correct executable path
-        charmmManipulation.executeCHARMM(charmm_exe="charmm")
+        # charmmManipulation.executeCHARMM(charmm_exe="charmm")
+        charmmManipulation.createOpenMMSystem()
         charmmManipulation.applyHMR()


### PR DESCRIPTION
There were a few things missing for starting openMM runs, namely:

- `step4_equilibration.inp` and `step5_production.inp`
- we need to create a `sysinfo.dat` file in which we write the box size information (from the previously generated `step3_pbcsetup.str` file
- all of this is applied in a new function called **createOpenMMsystem**

I also changed a few things:

- If HMR is applied but can't be done (because the file is missing since step3 failed) there will be an error but macha will move on with the next ligand
- I reverted all changes from yesterday, concerning distinguishing between maestro and charmm-gui pdbs (it was not working like we thougth)
- 