### PR TITLE
Input: protein + multiple ligands

### DIFF
--- a/macha/main.py
+++ b/macha/main.py
@@ -5,7 +5,7 @@ Created on Mon Jul 25 12:03:58 2022
 
 @author: Johannes Karwounopoulos and Åsmund Kaupang
 """
-
+import argparse
 from functions import checkInput, Preparation, CharmmManipulation
 
 ################################################################################
@@ -15,7 +15,7 @@ from functions import checkInput, Preparation, CharmmManipulation
 parent_dir = "."
 original_dir = "original"
 input_ext = "pdb"  # exclusive support for PDB
-protein_name = "protein" # = protein.pdb
+protein_name = "protein" # -> protein.pdb
 cgenff_path = "/site/raid2/johannes/programs/silcsbio/silcsbio.2022.1/cgenff/cgenff"
 
 ################################################################################
@@ -26,13 +26,29 @@ cgenff_path = "/site/raid2/johannes/programs/silcsbio/silcsbio.2022.1/cgenff/cge
 # If protein.pdb is found, assume ligands alone.
 protein_id, ligand_ids = checkInput(parent_dir = parent_dir, original_dir = original_dir, protein_name = protein_name)
 
+# ARGUMENT HANDLING
+# Initialize
+parser = argparse.ArgumentParser(description='Options')
+# Add expected/possible arguments
+parser.add_argument('-nc', '--nocomplex', action='store_true', help="Toggle production of waterboxes only (no complexes)")
+# Parse arguments
+args = parser.parse_args()
+
+# Determine which environments/run types will be used
+if args.nocomplex == True:
+    no_complex = True
+    envs = ["waterbox"]
+    print("Attention: Only waterboxes will be produced!")
+else:
+    no_complex = False
+    envs = ["waterbox", "complex"]
+
 # ITERATE THROUGH LIGANDS
 for ligand_id in ligand_ids:
-    
-    print(f"\n")
+
     print(f"Processing ligand {ligand_id}")
 
-    for env in ["waterbox", "complex"]:
+    for env in envs:
         # Preparation of ligands
         # Instantiate class
         preparation = Preparation(
@@ -45,13 +61,13 @@ for ligand_id in ligand_ids:
 
         # Check input types
         segids, df = preparation.checkInputType()
-        
+
         # Make a Transformato style folder structure
         preparation.makeTFFolderStructure()
 
         # Create CHARMM Coordinate files
         segids, used_segids = preparation.createCRDfiles(segids, df)
-        print("The following segment IDs were found/created:")
+        print("The following segment IDs were found/assigned:")
         print(*segids)
         print("The following segment IDs were used/not excluded:")
         print(*used_segids)

--- a/macha/main.py
+++ b/macha/main.py
@@ -15,7 +15,7 @@ from functions import checkInput, Preparation, CharmmManipulation
 parent_dir = "."
 original_dir = "original"
 input_ext = "pdb"  # exclusive support for PDB
-protein_name = None # = protein.pdb
+protein_name = "protein" # = protein.pdb
 cgenff_path = "/site/raid2/johannes/programs/silcsbio/silcsbio.2022.1/cgenff/cgenff"
 
 ################################################################################
@@ -43,16 +43,19 @@ for ligand_id in ligand_ids:
             env=env,
         )
 
-        # Make a Transformato style folder structure
-        preparation.makeTFFolderStructure()
         # Check input types
         segids, df = preparation.checkInputType()
+        
+        # Make a Transformato style folder structure
+        preparation.makeTFFolderStructure()
+
         # Create CHARMM Coordinate files
         segids, used_segids = preparation.createCRDfiles(segids, df)
         print("The following segment IDs were found/created:")
         print(*segids)
         print("The following segment IDs were used/not excluded:")
         print(*used_segids)
+
         # Get the toppar stream from a local CGenFF binary
         preparation.getTopparFromLocalCGenFF(cgenff_path=cgenff_path)
 
@@ -68,8 +71,10 @@ for ligand_id in ligand_ids:
         
         # Copy Files from the template folder
         charmmManipulation.copyFiles()
+
         # Modify step1_pdbreader.inp to read in correct amount of chains/residues
         charmmManipulation.modifyStep1(used_segids)
+
         # Run Charmm giving the correct executable path
         charmmManipulation.executeCHARMM(charmm_exe="charmm")
         charmmManipulation.createOpenMMSystem()


### PR DESCRIPTION
Apparently working solution for the input of a protein (complex or apoprotein) and multiple ligands. Waterboxes and complexes with each ligand are produced. Old functionality is apparently maintained, but to use ligand-only input PDBs for exclusive waterbox production now "requires" a command-line argument -nc, --nocomplex to avoid the production of a complex that is identical to the waterbox (and so, inefficient).