### PR TITLE
option for deselecting ions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__
 # Files created during testing
 macha/cdk2_l32/
 macha/tyk2_l23/
+macha/data/tyk2_l23/
+macha/data/cdk2_l32/
 
 # Distribution / packaging
 .Python

--- a/macha/data/templates/default/omm_step5_production.inp
+++ b/macha/data/templates/default/omm_step5_production.inp
@@ -1,7 +1,6 @@
 nstep       = 250000                            # Number of steps to run
 dt          = 0.002                             # Time-step (ps)
 
-gen_vel     = yes                                            
 nstout      = 1000                              # Writing output frequency (steps)
 nstdcd      = 50000                             # Writing coordinates trajectory frequency (steps)
                                             

--- a/macha/data/templates/temp_asfe.yaml
+++ b/macha/data/templates/temp_asfe.yaml
@@ -24,11 +24,11 @@ system:
 simulation:
   ################
   parameters:
-    nstep: 2500000
+    nstep: NUMBEROFSTEPS
     nstdcd: 500
     nstout: 2000
-    cons: HBonds
-    dt: 0.002
+    cons: None
+    dt: TIMESTEP
     mini_nstep: 5000
 
   workload-manager : "slurm"

--- a/macha/functions.py
+++ b/macha/functions.py
@@ -865,8 +865,15 @@ class CharmmManipulation:
         #except:
         #    print("Masses were left unchanged! HMR not possible, check your output! ")
 
+    def _apply_constraints(self,fout):
 
-    def createTFYamlFile(self):
+        with open(fout,"r") as file:
+            filedata = file.read()
+        filedata = filedata.replace("cons: None","cons: HBonds")
+        with open(fout,"w") as file:
+            file.write(filedata)
+
+    def createTFYamlFile(self, dt = 0.001, nstep = 2500000):
         
         try:
             os.makedirs(f"{self.parent_dir}/config")
@@ -886,8 +893,17 @@ class CharmmManipulation:
                 elif line.strip().startswith("tlc"):
                     new_line = line.replace("UNK",f"{self.resname}")
                     fout.write(new_line)
+                elif line.strip().startswith("dt:"):
+                    new_line = line.replace("TIMESTEP", str(dt))
+                    fout.write(new_line)
+                elif line.strip().startswith("nstep:"):
+                    new_line = line.replace("NUMBEROFSTEPS", str(nstep))
+                    fout.write(new_line)
                 else: 
                     fout.write(line)
 
             fin.close()
             fout.close()
+
+            if dt != 0.001:
+                self._apply_constraints(fout.name)

--- a/macha/main.py
+++ b/macha/main.py
@@ -13,7 +13,7 @@ from functions import checkInput, Preparation, CharmmManipulation
 ################################################################################
 
 parent_dir = "."
-original_dir = "original"
+original_dir = "data/original"
 input_ext = "pdb"  # exclusive support for PDB
 protein_name = "protein" # -> protein.pdb
 cgenff_path = "/site/raid2/johannes/programs/silcsbio/silcsbio.2022.1/cgenff/cgenff"
@@ -96,3 +96,4 @@ for ligand_id in ligand_ids:
         charmmManipulation.executeCHARMM(charmm_exe="charmm")
         charmmManipulation.createOpenMMSystem()
         charmmManipulation.applyHMR()
+        charmmManipulation.createTFYamlFile(dt=0.002)

--- a/test.yaml
+++ b/test.yaml
@@ -3,8 +3,8 @@
 system:
   ################
   structure1:
-    name: "methanol"
-    tlc: "unk"
+    name: "methane"
+    tlc: "UNL"
     vacuum:
       dirname: "vacuum"
       psf_file_name: "step3_input"
@@ -27,8 +27,8 @@ simulation:
     nstep: 2500000
     nstdcd: 500
     nstout: 2000
-    cons: HBonds
-    dt: 0.002
+    cons: None
+    dt: 0.001
     mini_nstep: 5000
 
   workload-manager : "slurm"


### PR DESCRIPTION
When only the waterbox is needed, e.g. for absolute solvation free energy simulations, ions are not needed. Thus, I included a possibility in the `CharmmManipulation` class to deselect the build ions process with `include_ions=False`:
```
      charmmManipulation = CharmmManipulation(
          parent_dir=parent_dir,
          ligand_id=ligand_id,
          original_dir=original_dir,
          resname=preparation.resname,
          env=env,
          include_ions=True,
      )
```
The default behavior is still, that ions are included!
Additionally, I enhanced the `createYamlFile` function, it is now possible to pass a timestep `dt` and the number of steps `nstep`